### PR TITLE
fix userId not being send as customer_id in track & page events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,4 @@
+'use strict';
 
 /**
  * Module dependencies.
@@ -58,8 +59,8 @@ Blueshift.prototype.page = function(page) {
 
   var properties = page.properties();
   properties._bsft_source = 'segment.com';
-  properties.customer_id = page.userId();
-  properties.anonymousId = page.anonymousId();
+  properties.customer_id = this.analytics.user().id();
+  properties.anonymousId = this.analytics.user().anonymousId();
   properties.category = page.category();
   properties.name = page.name();
 
@@ -102,8 +103,8 @@ Blueshift.prototype.identify = function(identify) {
 Blueshift.prototype.track = function(track) {
   var properties = track.properties();
   properties._bsft_source = 'segment.com';
-  properties.customer_id = track.userId();
-  properties.anonymousId = track.anonymousId();
+  properties.customer_id = this.analytics.user().id();
+  properties.anonymousId = this.analytics.user().anonymousId();
 
   window.blueshift.track(track.event(), removeBlankAttributes(properties));
 };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,4 @@
+'use strict';
 
 var Analytics = require('analytics.js-core').constructor;
 var integration = require('analytics.js-integration');
@@ -128,21 +129,27 @@ describe('Blueshift', function() {
 
       it('should send an event', function() {
         analytics.track('event');
-        var properties = {
+        analytics.called(window.blueshift.track, 'event', {
           _bsft_source: 'segment.com',
           anonymousId: analytics.user().anonymousId()
-        };
-        analytics.called(window.blueshift.track, 'event', properties);
+        });
       });
-
       it('should send an event with properties', function() {
         analytics.track('event', { property: true });
-        var properties = {
+        analytics.called(window.blueshift.track, 'event', {
           _bsft_source: 'segment.com',
           anonymousId: analytics.user().anonymousId(),
           property: true
-        };
-        analytics.called(window.blueshift.track, 'event', properties);
+        });
+      });
+      it('should send an event with customer_id', function() {
+        analytics.identify('123');
+        analytics.track('event');
+        analytics.called(window.blueshift.track, 'event', {
+          _bsft_source: 'segment.com',
+          customer_id: '123',
+          anonymousId: analytics.user().anonymousId()
+        });
       });
     });
 


### PR DESCRIPTION
@ndhoule `customer_id` in our integration for track and page events is currently always returning null.  This fixes the issue. LMK if anything. 
