### PR TITLE
correctly alias firstName and lastName

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,9 @@ Blueshift.prototype.page = function(page) {
  * Trait Aliases.
  */
 var traitAliases = {
-  created: 'created_at'
+  created: 'created_at',
+  firstName: 'firstname',
+  lastName: 'lastname'
 };
 
 /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -113,9 +113,11 @@ describe('Blueshift', function() {
       });
 
       it('should send traits', function() {
-        analytics.identify({ trait: true });
+        analytics.identify({ trait: true, firstName: 'ham', lastName: 'solo' });
         analytics.called(window.blueshift.identify, {
           trait: true,
+          firstname: 'ham',
+          lastname: 'solo',
           _bsft_source: 'segment.com',
           anonymousId: analytics.user().anonymousId()
         });


### PR DESCRIPTION
https://segment.phacility.com/T1239

we were not sending `firstName` and `lastName` properly. They must be aliased as `firstname` and `lastname`. That way these special traits won't be seen as custom traits in Blueshift.
